### PR TITLE
Addition of SciPy to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,5 +6,6 @@ dependencies:
   - pandas=0.25.0
   - numpy=1.16.0
   - matplotlib=3.1.1
+  - scipy=1.2.1
   - jupyter=1.0.0
   - jupyter_contrib_nbextensions=0.5.1


### PR DESCRIPTION
SciPy is a dependency of NetworkX, but it is not listed in the "dependencies" section of the environment.yml file. Without it, as soon as any NetworkX functions are called and exception is thrown.
In this pull request a new line has been added to environment.yml listing SciPy 1.2.1 among the libraries that must be installed when the virtual environment is created.
Thank you. 